### PR TITLE
[feat] 영화 상세정보 조회 기능추가, spring 버전 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.1.8'
+	id 'org.springframework.boot' version '3.2.2'
 	id 'io.spring.dependency-management' version '1.1.4'
 }
 
@@ -28,6 +28,10 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	//Json
+	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+	implementation group: 'org.json', name: 'json', version: '20231013'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/mookive/mookive_backend/movie/application/dto/response/MovieResponse.java
+++ b/src/main/java/com/mookive/mookive_backend/movie/application/dto/response/MovieResponse.java
@@ -1,0 +1,27 @@
+package com.mookive.mookive_backend.movie.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MovieResponse {
+
+    @Getter
+    @NoArgsConstructor
+    public static class MovieDetailResponse {
+        private String title;
+        private String director;
+        private String genre;
+        private String year;
+        private String plot;
+
+        @Builder
+        public MovieDetailResponse(String title, String director, String genre, String year, String plot) {
+            this.title = title;
+            this.director = director;
+            this.genre = genre;
+            this.year = year;
+            this.plot = plot;
+        }
+    }
+}

--- a/src/main/java/com/mookive/mookive_backend/movie/application/infra/KmdbComponent.java
+++ b/src/main/java/com/mookive/mookive_backend/movie/application/infra/KmdbComponent.java
@@ -1,0 +1,15 @@
+package com.mookive.mookive_backend.movie.application.infra;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+@Component
+@HttpExchange
+public interface KmdbComponent {
+
+    @GetExchange()
+    String findMovieByTitle(@RequestParam String collection, @RequestParam String ServiceKey,
+                                         @RequestParam String query, @RequestParam String detail);
+}

--- a/src/main/java/com/mookive/mookive_backend/movie/application/infra/KoficComponent.java
+++ b/src/main/java/com/mookive/mookive_backend/movie/application/infra/KoficComponent.java
@@ -1,0 +1,15 @@
+package com.mookive.mookive_backend.movie.application.infra;
+
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+@Component
+@HttpExchange
+public interface KoficComponent {
+
+    @GetExchange()
+    String findMovieByTitle(@RequestParam String key, @RequestParam String movieNm);
+}

--- a/src/main/java/com/mookive/mookive_backend/movie/application/infra/RestClientConfig.java
+++ b/src/main/java/com/mookive/mookive_backend/movie/application/infra/RestClientConfig.java
@@ -1,0 +1,32 @@
+package com.mookive.mookive_backend.movie.application.infra;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public KmdbComponent kmdbService() {
+        RestClient restClient = RestClient.builder()
+                .baseUrl("http://api.koreafilm.or.kr/openapi-data2/wisenut/search_api/search_json2.jsp").build();
+
+        RestClientAdapter adapter = RestClientAdapter.create(restClient);
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builderFor(adapter).build();
+        return factory.createClient(KmdbComponent.class);
+    }
+
+    @Bean
+    public KoficComponent koficService() {
+        RestClient restClient = RestClient.builder()
+                .baseUrl("http://www.kobis.or.kr/kobisopenapi/webservice/rest/movie/searchMovieList.json").build();
+
+        RestClientAdapter adapter = RestClientAdapter.create(restClient);
+        HttpServiceProxyFactory factory = HttpServiceProxyFactory.builderFor(adapter).build();
+        return factory.createClient(KoficComponent.class);
+    }
+}

--- a/src/main/java/com/mookive/mookive_backend/movie/application/mapper/MovieMapper.java
+++ b/src/main/java/com/mookive/mookive_backend/movie/application/mapper/MovieMapper.java
@@ -1,0 +1,17 @@
+package com.mookive.mookive_backend.movie.application.mapper;
+
+import com.mookive.mookive_backend.movie.application.dto.response.MovieResponse;
+import com.mookive.mookive_backend.movie.domain.entity.Movie;
+
+public class MovieMapper {
+
+    public static MovieResponse.MovieDetailResponse mapToMovieDetailResponse(Movie movie) {
+        return MovieResponse.MovieDetailResponse.builder()
+                .title(movie.getTitle())
+                .director(movie.getDirector())
+                .genre(movie.getGenre())
+                .year(movie.getYear())
+                .plot(movie.getPlot())
+                .build();
+    }
+}

--- a/src/main/java/com/mookive/mookive_backend/movie/application/service/MovieGetService.java
+++ b/src/main/java/com/mookive/mookive_backend/movie/application/service/MovieGetService.java
@@ -1,0 +1,133 @@
+package com.mookive.mookive_backend.movie.application.service;
+
+import com.mookive.mookive_backend.movie.application.dto.response.MovieResponse;
+import com.mookive.mookive_backend.movie.application.infra.KmdbComponent;
+import com.mookive.mookive_backend.movie.application.infra.KoficComponent;
+import com.mookive.mookive_backend.movie.application.mapper.MovieMapper;
+import com.mookive.mookive_backend.movie.domain.entity.Movie;
+import com.mookive.mookive_backend.movie.domain.service.MovieQueryService;
+import com.mookive.mookive_backend.movie.domain.service.MovieSaveService;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MovieGetService {
+
+    private final MovieQueryService movieQueryService;
+    private final MovieSaveService movieSaveService;
+    private final KmdbComponent kmdbComponent;
+    private final KoficComponent koficComponent;
+
+    @Value("${kmdb.service-key}")
+    private String kmdbServiceKey;
+
+    @Value("${kmdb.collection}")
+    private String collection;
+
+    @Value("${kofic.service-key}")
+    private String koficKey;
+
+    /**
+    TODO: 예외처리
+     */
+    public MovieResponse.MovieDetailResponse getMovieInfo(String title) throws JSONException {
+        Movie movie = movieQueryService.findByTitle(title);
+        if(movie == null) {
+            KmdbResponse kmdbResponse = getKmdbResponse(title);
+            KoficResponse koficResponse = getKoficResponse(title);
+            movie = Movie.builder()
+                    .title(koficResponse.getTitle())
+                    .director(kmdbResponse.getDirector())
+                    .genre(kmdbResponse.getGenre())
+                    .plot(kmdbResponse.getPlot())
+                    .year(koficResponse.getYear())
+                    .build();
+            movieSaveService.saveMovie(movie);
+        }
+        return MovieMapper.mapToMovieDetailResponse(movie);
+    }
+
+    private JSONObject getDataResponse(String title) {
+        JSONObject json = new JSONObject(kmdbComponent.findMovieByTitle(collection, kmdbServiceKey, title, "N"));
+        JSONArray dataArray = (JSONArray) json.get("Data");
+        JSONObject dataObject = (JSONObject) dataArray.get(0);
+        JSONArray dataResult = (JSONArray) dataObject.get("Result");
+        return (JSONObject) dataResult.get(0);
+    }
+
+    private KmdbResponse getKmdbResponse(String title) {
+        JSONObject dataObject = getDataResponse(title);
+        System.out.println(dataObject.toString());
+        Object genre = dataObject.get("genre");
+        Object director = getDirector(dataObject);
+        Object plot = getPlotText(dataObject);
+        return KmdbResponse.builder()
+                .director((String) director)
+                .genre((String) genre)
+                .plot((String) plot)
+                .build();
+    }
+
+    private static Object getPlotText(JSONObject dataObject) {
+        JSONObject plotObject = (JSONObject) dataObject.get("plots");
+        JSONArray plotArray = (JSONArray) plotObject.get("plot");
+        JSONObject plotData = (JSONObject) plotArray.get(0);
+        return plotData.get("plotText");
+    }
+
+    private static Object getDirector(JSONObject dataObject) {
+        JSONObject directorObject = (JSONObject) dataObject.get("directors");
+        JSONArray directorArray = (JSONArray) directorObject.get("director");
+        JSONObject directorData = (JSONObject) directorArray.get(0);
+        return directorData.get("directorNm");
+    }
+
+    private KoficResponse getKoficResponse(String movieTitle) {
+        JSONObject json = new JSONObject(koficComponent.findMovieByTitle(koficKey, movieTitle));
+        JSONObject jsonObject = (JSONObject) json.get("movieListResult");
+        JSONArray dataResult = (JSONArray) jsonObject.get("movieList");
+        JSONObject movie = (JSONObject) dataResult.get(0); //결과값이 여러개일 때 문제
+        String title = movie.get("movieNm").toString();
+        System.out.println(title);
+        String year = movie.get("openDt").toString().substring(0, 4);
+        return KoficResponse.builder()
+                .title(title)
+                .year(year)
+                .build();
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    private static class KmdbResponse {
+        private String director;
+        private String genre;
+        private String plot;
+
+        @Builder
+        public KmdbResponse(String director, String genre, String plot) {
+            this.director = director;
+            this.genre = genre;
+            this.plot = plot;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    private static class KoficResponse {
+        private String title;
+        private String year;
+
+        @Builder
+        public KoficResponse(String title, String year) {
+            this.title = title;
+            this.year = year;
+        }
+    }
+}

--- a/src/main/java/com/mookive/mookive_backend/movie/domain/entity/Movie.java
+++ b/src/main/java/com/mookive/mookive_backend/movie/domain/entity/Movie.java
@@ -1,0 +1,31 @@
+package com.mookive.mookive_backend.movie.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Movie {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String year;
+    private String director;
+    private String genre;
+    private String plot;
+
+    @Builder
+    public Movie(String title, String year, String director, String genre, String plot) {
+        this.title = title;
+        this.year = year;
+        this.director = director;
+        this.genre = genre;
+        this.plot = plot;
+    }
+}

--- a/src/main/java/com/mookive/mookive_backend/movie/domain/repository/MovieRepository.java
+++ b/src/main/java/com/mookive/mookive_backend/movie/domain/repository/MovieRepository.java
@@ -1,0 +1,9 @@
+package com.mookive.mookive_backend.movie.domain.repository;
+
+import com.mookive.mookive_backend.movie.domain.entity.Movie;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MovieRepository extends JpaRepository<Movie, Long> {
+
+    Movie findByTitle(String title);
+}

--- a/src/main/java/com/mookive/mookive_backend/movie/domain/service/MovieQueryService.java
+++ b/src/main/java/com/mookive/mookive_backend/movie/domain/service/MovieQueryService.java
@@ -1,0 +1,17 @@
+package com.mookive.mookive_backend.movie.domain.service;
+
+import com.mookive.mookive_backend.movie.domain.entity.Movie;
+import com.mookive.mookive_backend.movie.domain.repository.MovieRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MovieQueryService {
+
+    private final MovieRepository movieRepository;
+
+    public Movie findByTitle(String title) {
+        return movieRepository.findByTitle(title);
+    }
+}

--- a/src/main/java/com/mookive/mookive_backend/movie/domain/service/MovieSaveService.java
+++ b/src/main/java/com/mookive/mookive_backend/movie/domain/service/MovieSaveService.java
@@ -1,0 +1,18 @@
+package com.mookive.mookive_backend.movie.domain.service;
+
+import com.mookive.mookive_backend.movie.domain.entity.Movie;
+import com.mookive.mookive_backend.movie.domain.repository.MovieRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MovieSaveService {
+
+    private final MovieRepository movieRepository;
+
+    public void saveMovie(Movie movie) {
+        movieRepository.save(movie);
+    }
+
+}

--- a/src/main/java/com/mookive/mookive_backend/movie/presentation/MovieController.java
+++ b/src/main/java/com/mookive/mookive_backend/movie/presentation/MovieController.java
@@ -1,0 +1,22 @@
+package com.mookive.mookive_backend.movie.presentation;
+
+
+import com.mookive.mookive_backend.movie.application.dto.response.MovieResponse;
+import com.mookive.mookive_backend.movie.application.service.MovieGetService;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MovieController {
+
+    private final MovieGetService movieGetService;
+
+    @GetMapping("/movie/info")
+    public MovieResponse.MovieDetailResponse getMovieInfo(@RequestParam String title) throws JSONException {
+        return movieGetService.getMovieInfo(title);
+    }
+}


### PR DESCRIPTION
-  restClient 사용해 외부 API 호출하기 위해 spring 버전 변경
- 영화 도메인, repository 추가
- 영화 상세 정보 기능 추가
  - 디비에 검색하는 영화가 없으면 외부 api 호출해서 저장